### PR TITLE
Adding missing package for out-of-the-box Overleaf

### DIFF
--- a/latex/luximono.sty
+++ b/latex/luximono.sty
@@ -1,0 +1,33 @@
+\ProvidesPackage{luximono}[2004/01/26 loading LuxiMono as tt font (WaS)]
+\RequirePackage{keyval}
+\define@key{UlIX}{scaled}[0.87]{%
+  \expandafter\def\csname ul9@Scale\endcsname{#1}}
+\def\ProcessOptionsWithKV#1{%
+  \let\@tempc\relax
+  \let\UlIX@tempa\@empty
+  \@for\CurrentOption:=\@classoptionslist\do{%
+    \@ifundefined{KV@#1@\CurrentOption}%
+    {}%
+    {%
+      \edef\UlIX@tempa{\UlIX@tempa,\CurrentOption,}%
+      \@expandtwoargs\@removeelement\CurrentOption
+        \@unusedoptionlist\@unusedoptionlist
+    }%
+  }%
+  \edef\UlIX@tempa{%
+    \noexpand\setkeys{#1}{%
+      \UlIX@tempa\@ptionlist{\@currname.\@currext}%
+    }%
+  }%
+  \UlIX@tempa
+  \let\CurrentOption\@empty
+}
+\ProcessOptionsWithKV{UlIX}
+\AtEndOfPackage{%
+  \let\@unprocessedoptions\relax
+}
+
+\renewcommand{\ttdefault}{ul9}
+\endinput
+   
+


### PR DESCRIPTION
The luximono package is used, though not available in Overleaf. This adds the sty file manually. Overleaf is then able to compile out of the box. 

It seems to only be used for the signature lines in the statement of authorship, so a perhaps nicer fix would be circumventing the package entirely.